### PR TITLE
Use jsonArray.get(i) instead of calling it.next()

### DIFF
--- a/scala/sparker/src/main/scala-2.11/SparkER/Wrappers/JSONWrapper.scala
+++ b/scala/sparker/src/main/scala-2.11/SparkER/Wrappers/JSONWrapper.scala
@@ -43,9 +43,8 @@ object JSONWrapper {
           val data = obj.get(key)
           data match {
             case jsonArray: JSONArray =>
-              val it = data.asInstanceOf[JSONArray].iterator()
-              while (it.hasNext) {
-                p.addAttribute(KeyValue(key, it.next().toString))
+              for (i <- 0 until jsonArray.length) {
+                p.addAttribute(KeyValue(key, jsonArray.get(i).toString))
               }
             case _ => p.addAttribute(KeyValue(key, data.toString))
           }


### PR DESCRIPTION
Hi,
I noticed that `JSONArray.iterator()` is missing in the 20170516 version of org.json.
So I fixed the code to generate the index and use it as `jsonArray.get(i)`.

cheers,