### PR TITLE
Fix index out of range in get_comparison_size

### DIFF
--- a/python/sparker/objects.py
+++ b/python/sparker/objects.py
@@ -132,9 +132,9 @@ class BlockClean(object):
 		if len(a) > 1:
 			comparisons = 0
 			i = 0
-			while i < len(self.profiles):
+			while i < len(a):
 				j = i + 1
-				while j < len(self.profiles):
+				while j < len(a):
 					comparisons += len(a[i]) * len(a[j])
 					j += 1
 				i += 1


### PR DESCRIPTION
This function was causing me to get `index out of range` errors.

The issue was that `a` is filtered on `self.profiles` and the while loop conditions were still set on `self.profiles` but if they're filtered they wouldn't be same size. 